### PR TITLE
Add support for text callback

### DIFF
--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -28,6 +28,7 @@ class ReadMoreText extends StatefulWidget {
     this.lessStyle,
     this.delimiter = '... ',
     this.delimiterStyle,
+    this.onPressed,
   })  : assert(data != null),
         super(key: key);
 
@@ -48,6 +49,7 @@ class ReadMoreText extends StatefulWidget {
   final TextStyle moreStyle;
   final TextStyle lessStyle;
   final TextStyle delimiterStyle;
+  final VoidCallback pressed;
 
   @override
   ReadMoreTextState createState() => ReadMoreTextState();
@@ -61,7 +63,11 @@ class ReadMoreTextState extends State<ReadMoreText> {
   bool _readMore = true;
 
   void _onTapLink() {
-    setState(() => _readMore = !_readMore);
+    if (widget.onPressed != null) {
+      widget.onPressed();
+    } else {
+      setState(() => _readMore = !_readMore);
+    }
   }
 
   @override

--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -28,7 +28,7 @@ class ReadMoreText extends StatefulWidget {
     this.lessStyle,
     this.delimiter = '... ',
     this.delimiterStyle,
-    this.onPressed,
+    this.callback,
   })  : assert(data != null),
         super(key: key);
 
@@ -49,7 +49,7 @@ class ReadMoreText extends StatefulWidget {
   final TextStyle moreStyle;
   final TextStyle lessStyle;
   final TextStyle delimiterStyle;
-  final VoidCallback pressed;
+  final Function(bool val) callback;
 
   @override
   ReadMoreTextState createState() => ReadMoreTextState();
@@ -62,12 +62,11 @@ const String _kLineSeparator = '\u2028';
 class ReadMoreTextState extends State<ReadMoreText> {
   bool _readMore = true;
 
-  void _onTapLink() {
-    if (widget.onPressed != null) {
-      widget.onPressed();
-    } else {
-      setState(() => _readMore = !_readMore);
-    }
+  void _onTapLink() {  
+    setState((){
+    _readMore = !_readMore;
+    widget.callback?.call(_readMore);
+    });
   }
 
   @override


### PR DESCRIPTION
This fixes #1 to an extent. I don't have any use cases in mind where you'd want a callback for each state so I added support for a single state callback.

My use case for this is having the functionality to have 2 lines of text with an inline read more but when pressed the read more takes you to another screen with the full text rather than expanding the text.