### PR TITLE
'nullOk'. nullOk: nullOk - flutter 2.0

### DIFF
--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -84,7 +84,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
         widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
     final overflow = defaultTextStyle.overflow;
     final locale =
-        widget.locale ?? Localizations.localeOf(context);
+        widget.locale ?? Localizations.maybeLocaleOf(context);
     final colorClickableText =
         widget.colorClickableText ?? Theme.of(context).accentColor;
     final _defaultLessStyle = widget.lessStyle ??

--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -84,7 +84,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
         widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
     final overflow = defaultTextStyle.overflow;
     final locale =
-        widget.locale ?? Localizations.localeOf(context, nullOk: true);
+        widget.locale ?? Localizations.localeOf(context);
     final colorClickableText =
         widget.colorClickableText ?? Theme.of(context).accentColor;
     final _defaultLessStyle = widget.lessStyle ??


### PR DESCRIPTION
The nullOK is no longer available in APIs