### PR TITLE
Default text style for colorClickableText

### DIFF
--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -104,6 +104,8 @@ class ReadMoreTextState extends State<ReadMoreText> {
     TextStyle? effectiveTextStyle = widget.style;
     if (widget.style?.inherit ?? false) {
       effectiveTextStyle = defaultTextStyle.style.merge(widget.style);
+    } else {
+      effectiveTextStyle = const TextStyle();
     }
 
     final textAlign =
@@ -117,9 +119,9 @@ class ReadMoreTextState extends State<ReadMoreText> {
     final colorClickableText =
         widget.colorClickableText ?? Theme.of(context).colorScheme.secondary;
     final _defaultLessStyle = widget.lessStyle ??
-        effectiveTextStyle?.copyWith(color: colorClickableText);
+        effectiveTextStyle.copyWith(color: colorClickableText);
     final _defaultMoreStyle = widget.moreStyle ??
-        effectiveTextStyle?.copyWith(color: colorClickableText);
+        effectiveTextStyle.copyWith(color: colorClickableText);
     final _defaultDelimiterStyle = widget.delimiterStyle ?? effectiveTextStyle;
 
     TextSpan link = TextSpan(


### PR DESCRIPTION
The "style" and "moreStyle/lessStyle" arguments can be null. In that case, there is a problem that "colorClickableText" is not effective. 
As you can see below, if the "style" is null, "effectiveTextStyle"  will be null, and also "_defaultMoreStyle" will be null. This means "colorClickableText" is not effective. 

This PR might be related with #20 .

```dart
Widget build(BuildContext context) {
    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
    TextStyle? effectiveTextStyle = widget.style;
    if (widget.style?.inherit ?? false) {
      effectiveTextStyle = defaultTextStyle.style.merge(widget.style);
    } 
   ...
    final _defaultMoreStyle = widget.moreStyle ??
        effectiveTextStyle?.copyWith(color: colorClickableText);

```