### PR TITLE
Update readmore.dart

### DIFF
--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -35,6 +35,7 @@ class ReadMoreText extends StatefulWidget {
     this.callback,
     this.onLinkPressed,
     this.linkTextStyle,
+    this.isExpandable = true,
   }) : super(key: key);
 
   /// Used on TrimMode.Length
@@ -69,6 +70,9 @@ class ReadMoreText extends StatefulWidget {
   ///Called when state change between expanded/compress
   final Function(bool val)? callback;
 
+  /// Expand text on readMore press
+  final bool isExpandable;
+
   final ValueChanged<String>? onLinkPressed;
 
   final TextStyle? linkTextStyle;
@@ -98,8 +102,10 @@ class ReadMoreTextState extends State<ReadMoreText> {
   bool _readMore = true;
 
   void _onTapLink() {
-    setState(() {
+    if (widget.isExpandable) {
       _readMore = !_readMore;
+    }
+    setState(() {
       widget.callback?.call(_readMore);
     });
   }


### PR DESCRIPTION
Add an option to choose whether to expand text or not, on tap on read more text. By default it is true, so this will not change the default behaviour. This option comes in handy when we want to perform some action by pressing the read more button but do not want to expand text for example navigating to a new screen that will have the expanded text.