### PR TITLE
Add `ReadMoreText.rich` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.1.0]
+
+Contributed by [@maRci002](https://github.com/maRci002) - see PR [#59](https://github.com/jonataslaw/readmore/pull/59).
+
+- Added `ReadMoreText.rich` constructor for rich text formatting and interactivity, enhancing text presentation with customizable styles and interactive elements.
+
 ## [3.0.0]
 
 Contributed by [@maRci002](https://github.com/maRci002) - see PR [#54](https://github.com/jonataslaw/readmore/pull/54).

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ ReadMoreText(
   annotations: [
     Annotation(
       regExp: RegExp(r'#([a-zA-Z0-9_]+)'),
-      spanBuilder: ({required String text, TextStyle? textStyle}) => TextSpan(
+      spanBuilder: ({required String text, required TextStyle textStyle}) => TextSpan(
         text: text,
-        style: textStyle?.copyWith(color: Colors.blue),
+        style: textStyle.copyWith(color: Colors.blue),
       ),
     ),
     Annotation(

--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ ReadMoreText(
 );
 ```
 
+### Rich Text Example
+
+With the `ReadMoreText.rich` constructor, you can create text with rich formatting, including different colors, decorations, letter spacing, and interactive elements within a single widget.
+
+```dart
+ReadMoreText.rich(
+  TextSpan(
+    style: const TextStyle(color: Colors.black),
+    children: [
+      const TextSpan(text: 'Rich '),
+      const TextSpan(
+        text: 'Text',
+        style: TextStyle(
+          color: Colors.blue,
+          decoration: TextDecoration.underline,
+          letterSpacing: 5,
+          recognizer: TapGestureRecognizer()..onTap = () {
+            // Handle tap
+          },
+        ),
+      ),
+    ],
+  ),
+  trimMode: TrimMode.Line,
+  trimLines: 2,
+  colorClickableText: Colors.pink,
+  trimCollapsedText: '...Read more',
+  trimExpandedText: ' Less',
+);
+```
+
 ### Using Annotations
 
 The `Annotation` feature enhances the interactivity and functionality of the text content. You can define custom styles and interactions for patterns like hashtags, URLs, and mentions.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,11 +125,11 @@ class _DemoAppState extends State<DemoApp> {
                 ),
                 spanBuilder: ({
                   required String text,
-                  TextStyle? textStyle,
+                  required TextStyle textStyle,
                 }) {
                   return TextSpan(
                     text: text,
-                    style: (textStyle ?? const TextStyle()).copyWith(
+                    style: textStyle.copyWith(
                       decoration: TextDecoration.underline,
                       color: Colors.green,
                     ),
@@ -152,6 +152,7 @@ class _DemoAppState extends State<DemoApp> {
                   if (user == null) {
                     return TextSpan(
                       text: '@unknown user',
+                      // making TextStyle to non nullable doesn't break 3.0.0 version
                       style: (textStyle ?? const TextStyle()).copyWith(
                         fontWeight: FontWeight.bold,
                       ),
@@ -180,11 +181,11 @@ class _DemoAppState extends State<DemoApp> {
                 regExp: RegExp('#(?:[a-zA-Z0-9_]+)'),
                 spanBuilder: ({
                   required String text,
-                  TextStyle? textStyle,
+                  required TextStyle textStyle,
                 }) {
                   return TextSpan(
                     text: text,
-                    style: (textStyle ?? const TextStyle()).copyWith(
+                    style: textStyle.copyWith(
                       color: Colors.blueAccent,
                       height: 1.5,
                       letterSpacing: 5,
@@ -259,10 +260,11 @@ class _DemoAppState extends State<DemoApp> {
                 ),
               ],
             ),
+            style: TextStyle(inherit: false),
             trimMode: _trimMode,
             trimLines: _trimLines,
             trimLength: _trimLength,
-            colorClickableText: Colors.pink,
+            colorClickableText: Colors.blueAccent,
             trimCollapsedText: '...Read more',
             trimExpandedText: ' Less',
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,7 @@ class _DemoAppState extends State<DemoApp> {
 
   var _trimMode = TrimMode.Line;
   int _trimLines = 3;
-  int _trimLength = 240;
+  int _trimLength = 190;
 
   void _incrementTrimLines() => setState(() => _trimLines++);
 
@@ -224,6 +224,48 @@ class _DemoAppState extends State<DemoApp> {
               ),
             );
           },
+        ),
+        const Divider(
+          color: Color(0xFF167F67),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          // Rich version
+          child: ReadMoreText.rich(
+            TextSpan(
+              style: const TextStyle(color: Colors.black),
+              children: [
+                const TextSpan(text: 'The '),
+                const TextSpan(
+                  text: 'Flutter framework ',
+                  style: TextStyle(
+                    color: Colors.blue,
+                    decoration: TextDecoration.underline,
+                    letterSpacing: 5,
+                  ),
+                ),
+                const TextSpan(
+                  text: 'builds its layout via the composition of ',
+                ),
+                TextSpan(
+                  text: 'widgets, ',
+                  style: const TextStyle(color: Colors.green),
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = () => _showMessage('Widgets tapped!'),
+                ),
+                const TextSpan(
+                  text:
+                      'everything that you construct programmatically is a widget and these are compiled together to create the user interface.',
+                ),
+              ],
+            ),
+            trimMode: _trimMode,
+            trimLines: _trimLines,
+            trimLength: _trimLength,
+            colorClickableText: Colors.pink,
+            trimCollapsedText: '...Read more',
+            trimExpandedText: ' Less',
+          ),
         ),
       ],
     );

--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -18,7 +18,7 @@ class Annotation {
   });
 
   final RegExp regExp;
-  final TextSpan Function({required String text, TextStyle? textStyle})
+  final TextSpan Function({required String text, required TextStyle textStyle})
       spanBuilder;
 }
 
@@ -238,12 +238,14 @@ class ReadMoreTextState extends State<ReadMoreText> {
 
   Widget _builder(BuildContext context, bool isCollapsed, Widget? child) {
     final defaultTextStyle = DefaultTextStyle.of(context);
-    var effectiveTextStyle = widget.style;
+    TextStyle effectiveTextStyle;
     if (widget.style == null || widget.style!.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(widget.style);
+    } else {
+      effectiveTextStyle = widget.style!;
     }
     if (MediaQuery.boldTextOf(context)) {
-      effectiveTextStyle = effectiveTextStyle!
+      effectiveTextStyle = effectiveTextStyle
           .merge(const TextStyle(fontWeight: FontWeight.bold));
     }
     final registrar = SelectionContainer.maybeOf(context);
@@ -267,9 +269,9 @@ class ReadMoreTextState extends State<ReadMoreText> {
     final colorClickableText =
         widget.colorClickableText ?? Theme.of(context).colorScheme.secondary;
     final defaultLessStyle = widget.lessStyle ??
-        effectiveTextStyle?.copyWith(color: colorClickableText);
+        effectiveTextStyle.copyWith(color: colorClickableText);
     final defaultMoreStyle = widget.moreStyle ??
-        effectiveTextStyle?.copyWith(color: colorClickableText);
+        effectiveTextStyle.copyWith(color: colorClickableText);
     final defaultDelimiterStyle = widget.delimiterStyle ?? effectiveTextStyle;
 
     final link = TextSpan(
@@ -498,7 +500,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
 
   TextSpan _buildAnnotatedTextSpan({
     required String data,
-    required TextStyle? textStyle,
+    required TextStyle textStyle,
     required RegExp? regExp,
     required List<Annotation>? annotations,
   }) {

--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui show TextHeightBehavior;
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -22,7 +24,7 @@ class Annotation {
 
 class ReadMoreText extends StatefulWidget {
   const ReadMoreText(
-    this.data, {
+    String this.data, {
     super.key,
     this.isCollapsed,
     this.preDataText,
@@ -35,19 +37,63 @@ class ReadMoreText extends StatefulWidget {
     this.trimLength = 240,
     this.trimLines = 2,
     this.trimMode = TrimMode.Length,
-    this.style,
-    this.textAlign,
-    this.textDirection,
-    this.locale,
-    this.textScaler,
-    this.semanticsLabel,
     this.moreStyle,
     this.lessStyle,
     this.delimiter = '$_kEllipsis ',
     this.delimiterStyle,
     this.annotations,
     this.isExpandable = true,
-  });
+    this.style,
+    this.strutStyle,
+    this.textAlign,
+    this.textDirection,
+    this.locale,
+    this.softWrap,
+    this.overflow,
+    this.textScaler,
+    this.semanticsLabel,
+    this.textWidthBasis,
+    this.textHeightBehavior,
+    this.selectionColor,
+  })  : richData = null,
+        richPreData = null,
+        richPostData = null;
+
+  const ReadMoreText.rich(
+    TextSpan this.richData, {
+    super.key,
+    this.richPreData,
+    this.richPostData,
+    this.isCollapsed,
+    this.trimExpandedText = 'show less',
+    this.trimCollapsedText = 'read more',
+    this.colorClickableText,
+    this.trimLength = 240,
+    this.trimLines = 2,
+    this.trimMode = TrimMode.Length,
+    this.moreStyle,
+    this.lessStyle,
+    this.delimiter = '$_kEllipsis ',
+    this.delimiterStyle,
+    this.isExpandable = true,
+    this.style,
+    this.strutStyle,
+    this.textAlign,
+    this.textDirection,
+    this.locale,
+    this.softWrap,
+    this.overflow,
+    this.textScaler,
+    this.semanticsLabel,
+    this.textWidthBasis,
+    this.textHeightBehavior,
+    this.selectionColor,
+  })  : data = null,
+        annotations = null,
+        preDataText = null,
+        postDataText = null,
+        preDataTextStyle = null,
+        postDataTextStyle = null;
 
   final ValueNotifier<bool>? isCollapsed;
 
@@ -80,23 +126,41 @@ class ReadMoreText extends StatefulWidget {
   /// Textspan used after the data end or before the more/less
   final TextStyle? postDataTextStyle;
 
+  /// Rich version of [preDataText]
+  final TextSpan? richPreData;
+
+  /// Rich version of [postDataText]
+  final TextSpan? richPostData;
+
   final List<Annotation>? annotations;
 
   /// Expand text on readMore press
   final bool isExpandable;
 
   final String delimiter;
-  final String data;
+  final String? data;
+  final TextSpan? richData;
   final String trimExpandedText;
   final String trimCollapsedText;
   final Color? colorClickableText;
+  final TextStyle? delimiterStyle;
+
+  // DefaultTextStyle start
+
   final TextStyle? style;
+  final StrutStyle? strutStyle;
   final TextAlign? textAlign;
   final TextDirection? textDirection;
   final Locale? locale;
+  final bool? softWrap;
+  final TextOverflow? overflow;
   final TextScaler? textScaler;
   final String? semanticsLabel;
-  final TextStyle? delimiterStyle;
+  final TextWidthBasis? textWidthBasis;
+  final ui.TextHeightBehavior? textHeightBehavior;
+  final Color? selectionColor;
+
+  // DefaultTextStyle end
 
   @override
   ReadMoreTextState createState() => ReadMoreTextState();
@@ -174,26 +238,38 @@ class ReadMoreTextState extends State<ReadMoreText> {
 
   Widget _builder(BuildContext context, bool isCollapsed, Widget? child) {
     final defaultTextStyle = DefaultTextStyle.of(context);
-    TextStyle? effectiveTextStyle = widget.style;
-    if (widget.style?.inherit ?? false) {
+    var effectiveTextStyle = widget.style;
+    if (widget.style == null || widget.style!.inherit) {
       effectiveTextStyle = defaultTextStyle.style.merge(widget.style);
-    } else {
-      effectiveTextStyle = const TextStyle();
     }
+    if (MediaQuery.boldTextOf(context)) {
+      effectiveTextStyle = effectiveTextStyle!
+          .merge(const TextStyle(fontWeight: FontWeight.bold));
+    }
+    final registrar = SelectionContainer.maybeOf(context);
+    final textScaler = widget.textScaler ?? MediaQuery.textScalerOf(context);
 
     final textAlign =
         widget.textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start;
     final textDirection = widget.textDirection ?? Directionality.of(context);
-    final textScaler = widget.textScaler ?? MediaQuery.textScalerOf(context);
-    final overflow = defaultTextStyle.overflow;
     final locale = widget.locale ?? Localizations.maybeLocaleOf(context);
+    final softWrap = widget.softWrap ?? defaultTextStyle.softWrap;
+    final overflow = widget.overflow ?? defaultTextStyle.overflow;
+    final textWidthBasis =
+        widget.textWidthBasis ?? defaultTextStyle.textWidthBasis;
+    final textHeightBehavior = widget.textHeightBehavior ??
+        defaultTextStyle.textHeightBehavior ??
+        DefaultTextHeightBehavior.maybeOf(context);
+    final selectionColor = widget.selectionColor ??
+        DefaultSelectionStyle.of(context).selectionColor ??
+        DefaultSelectionStyle.defaultColor;
 
     final colorClickableText =
         widget.colorClickableText ?? Theme.of(context).colorScheme.secondary;
     final defaultLessStyle = widget.lessStyle ??
-        effectiveTextStyle.copyWith(color: colorClickableText);
+        effectiveTextStyle?.copyWith(color: colorClickableText);
     final defaultMoreStyle = widget.moreStyle ??
-        effectiveTextStyle.copyWith(color: colorClickableText);
+        effectiveTextStyle?.copyWith(color: colorClickableText);
     final defaultDelimiterStyle = widget.delimiterStyle ?? effectiveTextStyle;
 
     final link = TextSpan(
@@ -219,33 +295,46 @@ class ReadMoreTextState extends State<ReadMoreText> {
 
         TextSpan? preTextSpan;
         TextSpan? postTextSpan;
-        if (widget.preDataText != null) {
+
+        if (widget.richPreData != null) {
+          preTextSpan = widget.richPreData;
+        } else if (widget.preDataText != null) {
           preTextSpan = TextSpan(
             text: '${widget.preDataText!} ',
             style: widget.preDataTextStyle ?? effectiveTextStyle,
           );
         }
-        if (widget.postDataText != null) {
+
+        if (widget.richPostData != null) {
+          postTextSpan = widget.richPostData;
+        } else if (widget.postDataText != null) {
           postTextSpan = TextSpan(
             text: ' ${widget.postDataText!}',
             style: widget.postDataTextStyle ?? effectiveTextStyle,
           );
         }
 
-        final regExp = _mergeRegexPatterns(widget.annotations);
-
-        final annotatedText = _buildAnnotatedTextSpan(
-          data: widget.data,
-          textStyle: effectiveTextStyle,
-          regExp: regExp,
-          annotations: widget.annotations,
-        );
+        final TextSpan dataTextSpan;
+        if (widget.richData != null) {
+          assert(_isTextSpan(widget.richData!));
+          dataTextSpan = TextSpan(
+            style: effectiveTextStyle,
+            children: [widget.richData!],
+          );
+        } else {
+          dataTextSpan = _buildAnnotatedTextSpan(
+            data: widget.data!,
+            textStyle: effectiveTextStyle,
+            regExp: _mergeRegexPatterns(widget.annotations),
+            annotations: widget.annotations,
+          );
+        }
 
         // Create a TextSpan with data
         final text = TextSpan(
           children: [
             if (preTextSpan != null) preTextSpan,
-            annotatedText,
+            dataTextSpan,
             if (postTextSpan != null) postTextSpan,
           ],
         );
@@ -255,10 +344,13 @@ class ReadMoreTextState extends State<ReadMoreText> {
           text: link,
           textAlign: textAlign,
           textDirection: textDirection,
+          locale: locale,
           textScaler: textScaler,
           maxLines: widget.trimLines,
+          strutStyle: widget.strutStyle,
+          textWidthBasis: textWidthBasis,
+          textHeightBehavior: textHeightBehavior,
           ellipsis: overflow == TextOverflow.ellipsis ? widget.delimiter : null,
-          locale: locale,
         );
         textPainter.layout(maxWidth: maxWidth);
         final linkSize = textPainter.size;
@@ -299,50 +391,72 @@ class ReadMoreTextState extends State<ReadMoreText> {
         late final TextSpan textSpan;
         switch (widget.trimMode) {
           case TrimMode.Length:
-            if (widget.trimLength < widget.data.length) {
-              final effectiveAnnotatedText = isCollapsed
-                  ? _trimTextSpan(
-                      textSpan: annotatedText,
-                      spanStartIndex: 0,
-                      endIndex: widget.trimLength,
-                    ).textSpan
-                  : annotatedText;
-
-              textSpan = TextSpan(
-                style: effectiveTextStyle,
-                children: <TextSpan>[effectiveAnnotatedText, delimiter, link],
+            if (widget.richData != null) {
+              final trimResult = _trimTextSpan(
+                textSpan: dataTextSpan,
+                spanStartIndex: 0,
+                endIndex: widget.trimLength,
               );
+
+              if (trimResult.didTrim) {
+                textSpan = TextSpan(
+                  children: [
+                    if (isCollapsed) trimResult.textSpan else dataTextSpan,
+                    delimiter,
+                    link,
+                  ],
+                );
+              } else {
+                textSpan = dataTextSpan;
+              }
             } else {
-              textSpan = annotatedText;
+              if (widget.trimLength < widget.data!.length) {
+                final effectiveDataTextSpan = isCollapsed
+                    ? _trimTextSpan(
+                        textSpan: dataTextSpan,
+                        spanStartIndex: 0,
+                        endIndex: widget.trimLength,
+                      ).textSpan
+                    : dataTextSpan;
+
+                textSpan = TextSpan(
+                  children: <TextSpan>[
+                    effectiveDataTextSpan,
+                    delimiter,
+                    link,
+                  ],
+                );
+              } else {
+                textSpan = dataTextSpan;
+              }
             }
             break;
           case TrimMode.Line:
             if (textPainter.didExceedMaxLines) {
-              final effectiveAnnotatedText = isCollapsed
+              final effectiveDataTextSpan = isCollapsed
                   ? _trimTextSpan(
-                      textSpan: annotatedText,
+                      textSpan: dataTextSpan,
                       spanStartIndex: 0,
                       endIndex: endIndex,
                     ).textSpan
-                  : annotatedText;
+                  : dataTextSpan;
 
               textSpan = TextSpan(
-                style: effectiveTextStyle,
                 children: <TextSpan>[
-                  effectiveAnnotatedText,
+                  effectiveDataTextSpan,
                   if (linkLongerThanLine) const TextSpan(text: _kLineSeparator),
                   delimiter,
                   link,
                 ],
               );
             } else {
-              textSpan = annotatedText;
+              textSpan = dataTextSpan;
             }
             break;
         }
 
-        return Text.rich(
-          TextSpan(
+        return RichText(
+          text: TextSpan(
             children: [
               if (preTextSpan != null) preTextSpan,
               textSpan,
@@ -351,12 +465,25 @@ class ReadMoreTextState extends State<ReadMoreText> {
           ),
           textAlign: textAlign,
           textDirection: textDirection,
-          softWrap: true,
-          overflow: TextOverflow.clip,
+          locale: locale,
+          softWrap: softWrap,
+          overflow: overflow,
           textScaler: textScaler,
+          strutStyle: widget.strutStyle,
+          textWidthBasis: textWidthBasis,
+          textHeightBehavior: textHeightBehavior,
+          selectionRegistrar: registrar,
+          selectionColor: selectionColor,
         );
       },
     );
+    if (registrar != null) {
+      result = MouseRegion(
+        cursor: DefaultSelectionStyle.of(context).mouseCursor ??
+            SystemMouseCursors.text,
+        child: result,
+      );
+    }
     if (widget.semanticsLabel != null) {
       result = Semantics(
         textDirection: widget.textDirection,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: readmore
 description: A Flutter package that allows for dynamic expansion and collapse of text, as well as interactions with text patterns such as hashtags, URLs, and mentions.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/jonataslaw/loadmore
 
 environment:


### PR DESCRIPTION
closes #38

This PR enables the direct use of `TextSpan` instead of a plain `String`. In this case, annotations won't be triggered since the developer has total control over styling and adding interactions to parts of the text.