### PR TITLE
Fix excess lines in TrimMode.Line with correct emoji handling

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -268,6 +268,21 @@ class _DemoAppState extends State<DemoApp> {
             trimExpandedText: ' Less',
           ),
         ),
+        const Divider(
+          color: Color(0xFF167F67),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: ReadMoreText(
+            '😊' * 200,
+            trimMode: _trimMode,
+            trimLines: _trimLines,
+            trimLength: _trimLength,
+            colorClickableText: Colors.blueAccent,
+            trimCollapsedText: '...Read more',
+            trimExpandedText: ' Less',
+          ),
+        ),
       ],
     );
   }

--- a/lib/readmore.dart
+++ b/lib/readmore.dart
@@ -401,6 +401,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
                 textSpan: dataTextSpan,
                 spanStartIndex: 0,
                 endIndex: widget.trimLength,
+                splitByRunes: true,
               );
 
               if (trimResult.didTrim) {
@@ -414,14 +415,16 @@ class ReadMoreTextState extends State<ReadMoreText> {
               } else {
                 textSpan = dataTextSpan;
               }
-              // Constructed by ReadMoreText(...)
-            } else {
+            }
+            // Constructed by ReadMoreText(...)
+            else {
               if (widget.trimLength < widget.data!.runes.length) {
                 final effectiveDataTextSpan = isCollapsed
                     ? _trimTextSpan(
                         textSpan: dataTextSpan,
                         spanStartIndex: 0,
                         endIndex: widget.trimLength,
+                        splitByRunes: true,
                       ).textSpan
                     : dataTextSpan;
 
@@ -444,6 +447,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
                       textSpan: dataTextSpan,
                       spanStartIndex: 0,
                       endIndex: endIndex,
+                      splitByRunes: false,
                     ).textSpan
                   : dataTextSpan;
 
@@ -554,20 +558,22 @@ class ReadMoreTextState extends State<ReadMoreText> {
     required TextSpan textSpan,
     required int spanStartIndex,
     required int endIndex,
+    required bool splitByRunes,
   }) {
     var spanEndIndex = spanStartIndex;
 
     final text = textSpan.text;
-    // In the case of RichText(Constructed by ReadMoreText.rich(...)),
-    // "textSpan.text" is null. Therefore, in the process below, this function
-    // is recursively called for the contents of the children of TextSpan.
     if (text != null) {
-      final textLen = text.runes.length;
+      final textLen = splitByRunes ? text.runes.length : text.length;
       spanEndIndex += textLen;
 
       if (spanEndIndex >= endIndex) {
+        final newText = splitByRunes
+            ? String.fromCharCodes(text.runes, 0, endIndex - spanStartIndex)
+            : text.substring(0, endIndex - spanStartIndex);
+
         final nextSpan = TextSpan(
-          text: String.fromCharCodes(text.runes, 0, endIndex - spanStartIndex),
+          text: newText,
           children: null, // remove potential children
           style: textSpan.style,
           recognizer: textSpan.recognizer,
@@ -598,6 +604,7 @@ class ReadMoreTextState extends State<ReadMoreText> {
             textSpan: child,
             spanStartIndex: spanEndIndex,
             endIndex: endIndex,
+            splitByRunes: splitByRunes,
           );
 
           spanEndIndex = result.spanEndIndex;


### PR DESCRIPTION
closes #63

This pull request addresses the regression introduced by PR #62, which caused texts containing emojis to exceed the specified `trimLines` limit in `TrimMode.Line`. The issue stemmed from an approach that was effective in `TrimMode.Length` but not suitable for handling line-based trimming with emojis.

In the case of `TrimMode.Line`, [`TextPainter.getPositionForOffset`](https://api.flutter.dev/flutter/painting/TextPainter/getPositionForOffset.html) will provide the correct offset, and [`TextPainter.getOffsetBefore`](https://api.flutter.dev/flutter/painting/TextPainter/getOffsetBefore.html) ensures that an emoji will not be split in half. Therefore, in this case, the text should not be split by runes.